### PR TITLE
로그인, 로그아웃 기능 개발 완료

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,24 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.11.5</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/thinkbigdata/clevo/config/BootstrapCommanderLinerRunner.java
+++ b/src/main/java/com/thinkbigdata/clevo/config/BootstrapCommanderLinerRunner.java
@@ -1,0 +1,42 @@
+package com.thinkbigdata.clevo.config;
+
+import com.thinkbigdata.clevo.entity.Topic;
+import com.thinkbigdata.clevo.entity.User;
+import com.thinkbigdata.clevo.repository.TopicRepository;
+import com.thinkbigdata.clevo.repository.UserRepository;
+import com.thinkbigdata.clevo.role.Role;
+import com.thinkbigdata.clevo.topic.TopicName;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+@Component
+@RequiredArgsConstructor
+@Profile("dev")
+public class BootstrapCommanderLinerRunner implements CommandLineRunner {
+    private final TopicRepository topicRepository;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    @Override
+    public void run(String... args) throws Exception {
+        Topic topic1 = new Topic();
+        Topic topic2 = new Topic();
+        Topic topic3 = new Topic();
+        User admin = User.builder().email("admin@admin.com").name("admin").nickname("admin")
+                .age(20).gender("M").level(10).target(5)
+                .build();
+        admin.setPassword(passwordEncoder.encode("Admin1111!"));
+        admin.setRole(Role.ADMIN);
+
+        topic1.setTopicName(TopicName.TOPIC1);
+        topic2.setTopicName(TopicName.TOPIC2);
+        topic3.setTopicName(TopicName.TOPIC3);
+
+        topicRepository.saveAll(Arrays.asList(topic1, topic2, topic3));
+        userRepository.save(admin);
+    }
+}

--- a/src/main/java/com/thinkbigdata/clevo/config/RedisConfig.java
+++ b/src/main/java/com/thinkbigdata/clevo/config/RedisConfig.java
@@ -1,0 +1,25 @@
+package com.thinkbigdata.clevo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Bean
+    LettuceConnectionFactory connectionFactory() {
+        return new LettuceConnectionFactory();
+    }
+
+    @Bean
+    RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        template.setConnectionFactory(connectionFactory);
+        return template;
+    }
+}

--- a/src/main/java/com/thinkbigdata/clevo/config/SecurityConfig.java
+++ b/src/main/java/com/thinkbigdata/clevo/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.thinkbigdata.clevo.config;
 
+import com.thinkbigdata.clevo.filter.JwtAuthFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -9,19 +11,26 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+    private final JwtAuthFilter jwtAuthFilter;
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.httpBasic(HttpBasicConfigurer::disable).csrf(CsrfConfigurer::disable).formLogin(FormLoginConfigurer::disable)
+                .logout(configurer -> configurer.disable())
                 .headers(configurer -> configurer.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
                 .sessionManagement(configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         http.authorizeHttpRequests(authorize ->
-                authorize.requestMatchers("/actuator/**","/h2-console/**", "/registration", "/login", "/error").permitAll())
-                .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated());
+                authorize.requestMatchers("/actuator/**","/h2-console/**", "/registration", "/login",
+                            "/refresh/token", "/error").permitAll()
+                            .requestMatchers("/admin/**").hasAuthority("ADMIN")
+                            .anyRequest().authenticated())
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/thinkbigdata/clevo/controller/UserController.java
+++ b/src/main/java/com/thinkbigdata/clevo/controller/UserController.java
@@ -1,15 +1,18 @@
 package com.thinkbigdata.clevo.controller;
 
+import com.thinkbigdata.clevo.dto.TokenDto;
 import com.thinkbigdata.clevo.dto.UserDto;
 import com.thinkbigdata.clevo.dto.UserRegistrationDto;
 import com.thinkbigdata.clevo.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.Authentication;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,5 +23,41 @@ public class UserController {
     public ResponseEntity<UserDto> register(@RequestPart MultipartFile userImage, @RequestPart @Valid UserRegistrationDto registerDto) {
         UserDto userDto = userService.registerUser(registerDto, userImage);
         return ResponseEntity.ok(userDto);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<TokenDto> login(@RequestBody Map<String, String> login) {
+        if (!login.containsKey("email") || !login.containsKey("password"))
+            throw new RuntimeException("bad request");
+
+        TokenDto token = userService.login(login.get("email"), login.get("password"));
+
+        if (token == null)
+            throw new RuntimeException("not match");
+
+        return ResponseEntity.ok(token);
+    }
+
+    @GetMapping("/logout")
+    public ResponseEntity<?> logout(@RequestHeader("Authorization") String token, Authentication authentication) {
+        if (token.isBlank())
+            throw new RuntimeException("bad request");
+
+        if (StringUtils.hasText(token) && token.startsWith("Bearer"))
+            token = token.substring(7);
+        else throw new RuntimeException("bad request");
+
+        userService.logout(token, authentication.getName());
+        return ResponseEntity.status(200).build();
+    }
+
+    @PostMapping("/refresh/token")
+    public ResponseEntity<TokenDto> refreshToken(@RequestBody Map<String, String> token) {
+        if (!token.containsKey("refresh"))
+            throw new RuntimeException("bad request");
+
+        TokenDto tokenDto = userService.refreshToken(token.get("refresh"));
+
+        return ResponseEntity.ok(tokenDto);
     }
 }

--- a/src/main/java/com/thinkbigdata/clevo/dto/TokenDto.java
+++ b/src/main/java/com/thinkbigdata/clevo/dto/TokenDto.java
@@ -1,0 +1,10 @@
+package com.thinkbigdata.clevo.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class TokenDto {
+    private String access;
+    private String refresh;
+}

--- a/src/main/java/com/thinkbigdata/clevo/entity/RefreshToken.java
+++ b/src/main/java/com/thinkbigdata/clevo/entity/RefreshToken.java
@@ -1,0 +1,21 @@
+package com.thinkbigdata.clevo.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "RefreshToken")
+@Getter @Setter
+public class RefreshToken {
+    @Id @Column(name = "RefreshToken_id") @GeneratedValue(strategy = GenerationType.AUTO)
+    private Integer id;
+    @Column(name = "RefreshToken_value", nullable = false)
+    private String value;
+    @Column(name = "RefreshToken_user_email", nullable = false)
+    private String email;
+    @Column(name = "RefreshToken_expired_date")
+    private LocalDateTime expiredDate;
+}

--- a/src/main/java/com/thinkbigdata/clevo/entity/User.java
+++ b/src/main/java/com/thinkbigdata/clevo/entity/User.java
@@ -51,6 +51,6 @@ public class User {
         this.gender = gender;
         this.level = level;
         this.target = target;
-        this.role = Role.User;
+        this.role = Role.USER;
     }
 }

--- a/src/main/java/com/thinkbigdata/clevo/filter/JwtAuthFilter.java
+++ b/src/main/java/com/thinkbigdata/clevo/filter/JwtAuthFilter.java
@@ -1,0 +1,54 @@
+package com.thinkbigdata.clevo.filter;
+
+import com.thinkbigdata.clevo.util.token.TokenGenerateValidator;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+    private final TokenGenerateValidator tokenGenerateValidator;
+    private final RedisTemplate<String, String> redisTemplate;
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String accessToken = getToken(request.getHeader("Authorization"));
+
+        if (accessToken != null) {
+            try {
+                tokenGenerateValidator.validateToken(accessToken);
+            } catch (MalformedJwtException | IllegalArgumentException | UnsupportedJwtException | SignatureException e) {
+                response.sendError(401, "Invalid JWT Token");
+            } catch (ExpiredJwtException e) {
+                response.sendError(401, "Token Expired");
+            }
+            if (redisTemplate.opsForValue().get("logout:"+accessToken) == null) {
+                Authentication authentication = tokenGenerateValidator.createAuthentication(accessToken);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getToken(String token) {
+        if (StringUtils.hasText(token) && token.startsWith("Bearer")) {
+            token = token.substring(7);
+        } else token = null;
+        return token;
+    }
+}

--- a/src/main/java/com/thinkbigdata/clevo/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/thinkbigdata/clevo/repository/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package com.thinkbigdata.clevo.repository;
+
+import com.thinkbigdata.clevo.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Integer> {
+    Optional<RefreshToken> findByEmail(String email);
+
+    Optional<RefreshToken> findByValue(String token);
+}

--- a/src/main/java/com/thinkbigdata/clevo/role/Role.java
+++ b/src/main/java/com/thinkbigdata/clevo/role/Role.java
@@ -1,5 +1,5 @@
 package com.thinkbigdata.clevo.role;
 
 public enum Role {
-    User, Admin
+    USER, ADMIN
 }

--- a/src/main/java/com/thinkbigdata/clevo/service/UserDetailServiceImpl.java
+++ b/src/main/java/com/thinkbigdata/clevo/service/UserDetailServiceImpl.java
@@ -1,0 +1,24 @@
+package com.thinkbigdata.clevo.service;
+
+import com.thinkbigdata.clevo.entity.User;
+import com.thinkbigdata.clevo.repository.UserRepository;
+import com.thinkbigdata.clevo.util.token.CleVoUserDetail;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailServiceImpl implements UserDetailsService {
+    private final UserRepository userRepository;
+    @Override
+    public UserDetails loadUserByUsername(String username) {
+        User user = userRepository.findByEmail(username).orElseThrow(() ->
+            new UsernameNotFoundException("이메일 확인")
+        );
+
+        return new CleVoUserDetail(user.getEmail(), user.getRole());
+    }
+}

--- a/src/main/java/com/thinkbigdata/clevo/util/token/CleVoUserDetail.java
+++ b/src/main/java/com/thinkbigdata/clevo/util/token/CleVoUserDetail.java
@@ -1,0 +1,57 @@
+package com.thinkbigdata.clevo.util.token;
+
+import com.thinkbigdata.clevo.role.Role;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+
+public class CleVoUserDetail implements UserDetails {
+    private String email;
+    private Collection<GrantedAuthority> role;
+
+    public CleVoUserDetail(String email, Role role) {
+        this.email = email;
+        this.role = new ArrayList<>();
+        if (role.toString().equals("ADMIN")) this.role.add(new SimpleGrantedAuthority(Role.ADMIN.toString()));
+        this.role.add(new SimpleGrantedAuthority(Role.USER.toString()));
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return role;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return false;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+}

--- a/src/main/java/com/thinkbigdata/clevo/util/token/TokenGenerateValidator.java
+++ b/src/main/java/com/thinkbigdata/clevo/util/token/TokenGenerateValidator.java
@@ -1,0 +1,67 @@
+package com.thinkbigdata.clevo.util.token;
+
+import com.thinkbigdata.clevo.dto.TokenDto;
+import com.thinkbigdata.clevo.entity.User;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class TokenGenerateValidator {
+    private final UserDetailsService userDetailsService;
+    @Value("${token.access}") private Long accessExpired;
+    @Value("${token.refresh}") private Long refreshExpired;
+    @Value("${jwt.secret}") private String secret;
+    private byte[] bytes;
+    private Key key;
+
+    @PostConstruct
+    private void init() {
+        this.bytes = Base64.getDecoder().decode(secret);
+        this.key = Keys.hmacShaKeyFor(bytes);
+    }
+    public TokenDto generateToken(User user) {
+        Date date = Timestamp.valueOf(LocalDateTime.now());
+
+        String access = Jwts.builder().setSubject(user.getEmail())
+                .setExpiration(new Date(date.getTime() + accessExpired))
+                .setIssuedAt(date)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        String refresh = Jwts.builder().setSubject(user.getEmail())
+                .setExpiration(new Date(date.getTime() + refreshExpired))
+                .setIssuedAt(date)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        TokenDto token = new TokenDto();
+        token.setAccess(access);
+        token.setRefresh(refresh);
+        return token;
+    }
+
+    public void validateToken(String token) {
+        Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+    }
+
+    public Authentication createAuthentication(String token) {
+        String email = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().getSubject();
+        UserDetails userDetail =  userDetailsService.loadUserByUsername(email);
+        return new UsernamePasswordAuthenticationToken(userDetail, "", userDetail.getAuthorities());
+    }
+}

--- a/src/main/resources/yaml/application-dev.yml
+++ b/src/main/resources/yaml/application-dev.yml
@@ -22,7 +22,14 @@ spring:
   devtools:
     restart:
       enabled: true
-
+  data:
+    redis:
+      host: localhost
+      port: 6379
+  servlet:
+    multipart:
+      max-file-size: 50MB
+      max-request-size: 50MB
 logging:
   level:
     org:
@@ -48,3 +55,6 @@ management:
           - health
 
 img.location: D:/clevo/user/images
+token.access: 3600000 # 1000 * 60 * 60
+token.refresh: 1209600000 # 1000 * 60 * 60 * 24 * 14
+jwt.secret: vU10XArK82GV3MykKWIGR2r7fhchWttVLT9ioG4AIpU=

--- a/src/test/java/com/thinkbigdata/clevo/repository/LearningLogRepositoryTest.java
+++ b/src/test/java/com/thinkbigdata/clevo/repository/LearningLogRepositoryTest.java
@@ -41,7 +41,7 @@ class LearningLogRepositoryTest {
         user.setPassword("1111");
         user.setName("Name");
         user.setNickname("NickName");
-        user.setRole(Role.User);
+        user.setRole(Role.USER);
         user.setAge(20);
         user.setGender("M");
         userRepository.save(user);

--- a/src/test/java/com/thinkbigdata/clevo/repository/UserRepositoryTest.java
+++ b/src/test/java/com/thinkbigdata/clevo/repository/UserRepositoryTest.java
@@ -58,7 +58,7 @@ public class UserRepositoryTest {
         user.setPassword("1111");
         user.setName("Name");
         user.setNickname("NickName");
-        user.setRole(Role.User);
+        user.setRole(Role.USER);
         user.setAge(20);
         user.setGender("M");
 
@@ -79,7 +79,7 @@ public class UserRepositoryTest {
         user.setPassword("1111");
         user.setName("Name");
         user.setNickname("NickName");
-        user.setRole(Role.User);
+        user.setRole(Role.USER);
         user.setAge(20);
         user.setGender("M");
 
@@ -91,7 +91,7 @@ public class UserRepositoryTest {
         newuser.setPassword("1111");
         newuser.setName("Name");
         newuser.setNickname("NickName");
-        newuser.setRole(Role.User);
+        newuser.setRole(Role.USER);
         newuser.setAge(20);
         newuser.setGender("M");
 
@@ -108,7 +108,7 @@ public class UserRepositoryTest {
         user.setPassword("1111");
         user.setName("Name");
         user.setNickname("NickName");
-        user.setRole(Role.User);
+        user.setRole(Role.USER);
         user.setAge(20);
         user.setGender("M");
 
@@ -142,7 +142,7 @@ public class UserRepositoryTest {
         user.setPassword("1111");
         user.setName("Name");
         user.setNickname("NickName");
-        user.setRole(Role.User);
+        user.setRole(Role.USER);
         user.setAge(20);
         user.setGender("M");
         User savedUser = userRepository.save(user);

--- a/src/test/java/com/thinkbigdata/clevo/repository/UserSentenceRepositoryTest.java
+++ b/src/test/java/com/thinkbigdata/clevo/repository/UserSentenceRepositoryTest.java
@@ -42,7 +42,7 @@ class UserSentenceRepositoryTest {
         user.setPassword("1111");
         user.setName("Name");
         user.setNickname("NickName");
-        user.setRole(Role.User);
+        user.setRole(Role.USER);
         user.setAge(20);
         user.setGender("M");
         userRepository.save(user);


### PR DESCRIPTION
- RefreshToken Db에 저장 (리프레쉬 토큰 재발급용)
- BlackList token in-memory 저장 (로그아웃용)
- SecurityFilterChain에 JwtAuthFilter 등록
- JwtAuthFilter에서 SecurityContext에 Authentication 저장 (MVC Controller Layer에서 인증, 인가 수준 식별하기 위한 객체)